### PR TITLE
skip abstract

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 
 <body>
 
-  <section id='abstract' data-include="01_abstract.html"></section>
+  <!-- <section id='abstract' data-include="01_abstract.html"></section> -->
   <section id='sotd'></section>
   <!-- <section id="tof" class="informative appendix"></section> -->
   <section id='conformance'></section>


### PR DESCRIPTION
Er staat `Cannot GET /01_abstract.html` onder "Samenvatting" nu de lege "abstract" verwijderd is. ReSpec klaagt (error) als je het niet importeerd, maar om de melding in de snapshot te voorkomen deze aanpassingssuggestie.